### PR TITLE
Security and reliability fix for handling of coverage.data 

### DIFF
--- a/lib/cover_me/results.rb
+++ b/lib/cover_me/results.rb
@@ -6,9 +6,10 @@ module CoverMe
       def read_results(path = CoverMe.config.results.store)
         data = {}
         if File.exists?(path)
+          data = File.read(path, {:encoding => 'ASCII-8BIT', :mode => 'r'})
           begin
-            data = eval(File.read(path)) || {}
-          rescue SyntaxError
+            data = Marshal.load(data)
+          rescue
             data = {}
           end
         end
@@ -34,9 +35,10 @@ module CoverMe
             data[file] = results
           end
         end
-        
-        File.open(path, 'w') do |f|
-          f.write(data.inspect)
+
+        File.open(path, {:encoding => 'ASCII-8BIT', :mode => 'w'}) do |f|
+          data = Marshal.dump(data)
+          f.write(data)
         end
 
         return data

--- a/lib/cover_me/results.rb
+++ b/lib/cover_me/results.rb
@@ -6,7 +6,11 @@ module CoverMe
       def read_results(path = CoverMe.config.results.store)
         data = {}
         if File.exists?(path)
-          data = eval(File.read(path)) || {}
+          begin
+            data = eval(File.read(path)) || {}
+          rescue SyntaxError
+            data = {}
+          end
         end
         return data
       end
@@ -30,11 +34,11 @@ module CoverMe
             data[file] = results
           end
         end
-
+        
         File.open(path, 'w') do |f|
           f.write(data.inspect)
         end
-        
+
         return data
       end
       

--- a/spec/cover_me/results_spec.rb
+++ b/spec/cover_me/results_spec.rb
@@ -31,7 +31,14 @@ describe CoverMe::Results do
       res.should be_kind_of(Hash)
       res.should be_empty
     end
-    
+
+    it "should return empty results if reading the file fails with a Syntax error" do
+      File.stub!(:read).and_return('{garbage}')
+      res = CoverMe::Results.read_results
+      res.should be_kind_of(Hash)
+      res.should be_empty
+    end
+
   end
   
   describe "merge_results!" do
@@ -55,7 +62,7 @@ describe CoverMe::Results do
       res.should == @more_results
       File.read(@idontexist_path).should == res.inspect
     end
-    
+
   end
   
 end

--- a/spec/cover_me/results_spec.rb
+++ b/spec/cover_me/results_spec.rb
@@ -8,7 +8,7 @@ describe CoverMe::Results do
     res = {'file1' => [0, nil, 1],
            'file2' => [nil, 1, nil]}
     File.open(CoverMe.config.results.store, 'w') do |f|
-      f.write(res.inspect)
+      f.write(Marshal.dump(res))
     end
   end
   
@@ -53,14 +53,14 @@ describe CoverMe::Results do
       res.should be_kind_of(Hash)
       res.should == {'file1' => [0, 1, 2],
                      'file2' => [nil, 1, 0]}
-      File.read(CoverMe.config.results.store).should == res.inspect
+      File.read(CoverMe.config.results.store).should == Marshal.dump(res)
     end
     
     it "should merge the results and create a new file if there isn't one" do
       res = CoverMe::Results.merge_results!(@more_results, @idontexist_path)
       res.should be_kind_of(Hash)
       res.should == @more_results
-      File.read(@idontexist_path).should == res.inspect
+      File.read(@idontexist_path).should == Marshal.dump(res)
     end
 
   end


### PR DESCRIPTION
This fixes Issue #43 with a simple rescue block.  Code has a covering test.

Also migrates from using eval to ruby Marshal.  eval opens a possible attack vector for a sneaky gem.

Thanks for your work on cover_me.

Mikel
